### PR TITLE
#168666570 Super admin should not assign themselves a new role

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3472,9 +3472,9 @@
       }
     },
     "express-fileupload": {
-      "version": "1.1.6-alpha.5",
-      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.1.6-alpha.5.tgz",
-      "integrity": "sha512-M/PLB3moD1stnfYUHGtAVqfdjOz0VSY00NWnA9CpSEyPxhs/lEeperWOffaBzom+DO8Sq1z1okJOy2N4MDRYtA==",
+      "version": "1.1.6-alpha.4",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.1.6-alpha.4.tgz",
+      "integrity": "sha512-bYvYfMVuS3EedkrYTV44+e/w58TBtgog+YbKIdT6e+IgyJ51dmLDVNcMcwBvVVy0ngk4utXgrgKl2p5EubipVA==",
       "requires": {
         "busboy": "^0.2.14"
       }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -289,10 +289,10 @@ class Users {
       if (!details) {
         return Response.customResponse(res, 404, "user doesn't exist");
       }
-      if (rawData.userRole === 'Super Administrator') {
+      if (details.userRoles === 'Super Administrator') {
         return Response.customResponse(
           res,
-          404,
+          400,
           'What you are trying achieve can not be completed'
         );
       }


### PR DESCRIPTION
### What does this PR do?
Implement fix for super admin feature 
#### Description of Task to be completed?
- fixes the error of the super administrator being able to transfer powers to a different individual
#### How should this be manually tested?
- clone the repo and checkout to this branch  bg-fix-admin-role-setting-168666570
- Run seeds to add more data into the database sequelize db:seed: all
- Run npm run start:dev
- head over to postman and use the route:localhost:3000/api/v1/auth/signin
- log in as a super admin
```json
{
    "userEmail": "johndoe@gmail.com",
    "userPassword": "Root1123#"
}
```
- copy the token that will be used to access the updateRole route
- then use the route:localhost:3000/api/v1/auth/updateRole
```json
{
    "userEmail": "johndoe@gmail.com",
 "userRole": "Manager"
    
}
```
- To run the test run npm test
#### Any background context you want to provide?
- The super administrator should not be allowed to transfer powers for some reason
#### What are the relevant pivotal tracker stories?
[#168666570](https://www.pivotaltracker.com/story/show/168666570)
#### Screenshots (if appropriate)
<img width="1166" alt="Screen Shot 2019-09-20 at 17 01 36" src="https://user-images.githubusercontent.com/26383328/65337450-7555a500-dbc8-11e9-871f-3e1ff10c600b.png">

#### Questions:
N/A