### PR TITLE
#168131428 Users should be able to comment on Travel requests

### DIFF
--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -1,0 +1,63 @@
+/* eslint-disable class-methods-use-this */
+import Response from '../utils/response';
+import CommentService from '../services/commentService';
+
+/** Class representing comments controller. */
+class CommentController {
+  /**
+   * Creates a new comment.
+   * @param {object} req request
+   * @param {object} res response
+   * @returns {object} response object
+   */
+  async addComment(req, res) {
+    try {
+      const comment = req.body;
+      comment.user = req.user.id;
+      const addedComment = await CommentService.addComment(comment);
+      return Response.customResponse(res, 201, 'Comment added successfully', addedComment);
+    } catch (error) {
+      return Response.errorResponse(res, 500, 'Something went wrong', error);
+    }
+  }
+
+  /**
+   * gets all comments by request
+   * @param {object} req request
+   * @param {object} res response
+   * @returns {object} response
+   */
+  async getCommentsByRequest(req, res) {
+    try {
+      const comments = await CommentService.getCommentsByRequest(req.params.id);
+      return Response.customResponse(res, 200, 'Comments fetched successfully', comments);
+    } catch (error) {
+      return Response.errorResponse(res, 500, 'Something went wrong', error);
+    }
+  }
+
+  /**
+   * updates a comment
+   * @param {object} req request.
+   * @param {object} res response.
+   * @returns {object} response object.
+   */
+  async updateComment(req, res) {
+    try {
+      const { id } = req.params;
+      const commentExists = await CommentService.getCommentById(id);
+      if (!commentExists) return Response.errorResponse(res, 404, 'Error', 'Comment not found');
+      const updatedComment = await CommentService.updateComment(id, req.body);
+      return Response.customResponse(
+        res,
+        200,
+        'Comment updated successfully',
+        updatedComment[1][0]
+      );
+    } catch (error) {
+      return Response.errorResponse(res, 500, 'Something went wrong', error);
+    }
+  }
+}
+
+export default new CommentController();

--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -31,7 +31,7 @@ class Requests {
         result
       );
     } catch (error) {
-      next(error);
+      return next(error);
     }
   }
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -220,7 +220,7 @@ class Users {
         url
       );
     } catch (error) {
-      next(error);
+      return next(error);
     }
   }
 
@@ -258,7 +258,7 @@ class Users {
         'Password has been sucessfully changed. Proceed to login'
       );
     } catch (error) {
-      next(error);
+      return next(error);
     }
   }
 

--- a/src/database/migrations/20190922094659-create-comment.js
+++ b/src/database/migrations/20190922094659-create-comment.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-unused-vars */
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Comments', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user: {
+      type: Sequelize.INTEGER
+    },
+    comment: {
+      type: Sequelize.STRING
+    },
+    request: {
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('Comments')
+};

--- a/src/database/models/comment.js
+++ b/src/database/models/comment.js
@@ -1,0 +1,37 @@
+export default (sequelize, DataTypes) => {
+  const Comment = sequelize.define(
+    'Comment',
+    {
+      user: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        validate: {
+          isNumeric: true
+        }
+      },
+      comment: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      request: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        validate: {
+          isNumeric: true
+        }
+      }
+    },
+    {}
+  );
+  Comment.associate = (models) => {
+    Comment.belongsTo(models.Requests, {
+      foreignKey: 'request',
+      onDelete: 'CASCADE'
+    });
+    Comment.belongsTo(models.Users, {
+      foreignKey: 'user',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Comment;
+};

--- a/src/database/models/index.js
+++ b/src/database/models/index.js
@@ -8,12 +8,7 @@ const env = process.env.NODE_ENV || 'development';
 const config = configFile[env];
 const db = {};
 
-let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
-}
+const sequelize = new Sequelize(process.env[config.use_env_variable], config);
 
 fs.readdirSync(__dirname)
   .filter((file) => file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js')

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -60,6 +60,9 @@ module.exports = (sequelize, DataTypes) => {
       as: 'accommodations',
       foreignKey: 'requestId'
     });
+    Requests.hasMany(models.Comment, {
+      foreignKey: 'request'
+    });
   };
   return Requests;
 };

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -55,6 +55,9 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'userId',
       as: 'userProfile'
     });
+    Users.hasMany(models.Comment, {
+      foreignKey: 'user'
+    });
   };
   return Users;
 };

--- a/src/middlewares/userRoles.js
+++ b/src/middlewares/userRoles.js
@@ -1,4 +1,6 @@
 import Response from '../utils/response';
+import RequestService from '../services/requestService';
+import CommentService from '../services/commentService';
 /** Class representing a UserRole. */
 class Access {
   /**
@@ -34,5 +36,38 @@ class Access {
     }
     next();
   }
+
+  /**
+   * Checks if the user is the request owner or manager.
+   *@param {string} req  data.
+   * @param {string} res  data.
+   * @param {string} next data.
+   * @returns {string} object.
+   */
+  static async isOwnerOrManager(req, res, next) {
+    const request = await RequestService.findRequestByID(req.params.id);
+    if (!request) return Response.errorResponse(res, 404, 'Invalid request ID');
+    if (req.user.userRoles !== 'Manager' && req.user.id !== request.user) {
+      return Response.errorResponse(res, 403, "You don't have rights to complete this operation");
+    }
+    next();
+  }
+
+  /**
+   * Checks if the user is the request owner or manager.
+   *@param {string} req  data.
+   * @param {string} res  data.
+   * @param {string} next data.
+   * @returns {string} object.
+   */
+  static async isCommentOwner(req, res, next) {
+    const comment = await CommentService.getCommentById(req.params.id);
+    if (!comment) return Response.errorResponse(res, 404, 'Invalid comment ID');
+    if (req.user.id !== comment.user) {
+      return Response.errorResponse(res, 403, "You don't have rights to complete this operation");
+    }
+    next();
+  }
 }
+
 export default Access;

--- a/src/routes/api/requests.js
+++ b/src/routes/api/requests.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-unused-vars */
 import express from 'express';
 import Requests from '../../controllers/requestController';
+import Comments from '../../controllers/commentController';
 import requestsValidator from '../../validation/requestValidator';
+import commentsValidator from '../../validation/commentValidator';
 import verify from '../../middlewares/auth';
 import method from '../../utils/method';
 import location from '../../middlewares/validLocation';
+import Access from '../../middlewares/userRoles';
 
 const router = express.Router();
 
@@ -33,5 +36,27 @@ router
   .route('/my-requests')
   .get(verify, Requests.getMyRequests)
   .all(method);
+
+router.get(
+  '/:id/comments',
+  verify,
+  commentsValidator.getComments,
+  Access.isOwnerOrManager,
+  Comments.getCommentsByRequest
+);
+router.post(
+  '/:id/comment',
+  verify,
+  commentsValidator.addComment,
+  Access.isOwnerOrManager,
+  Comments.addComment
+);
+router.put(
+  '/comments/:id',
+  verify,
+  commentsValidator.updateComment,
+  Access.isCommentOwner,
+  Comments.updateComment
+);
 
 module.exports = router;

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-useless-catch */
+import database from '../database/models';
+
+const { Comment } = database;
+
+/** Class representing a Comment service */
+class CommentService {
+  /**
+   * Creates a new comment.
+   * @param {object} comment The first number.
+   * @returns {object} The User object.
+   */
+  static async addComment(comment) {
+    try {
+      return await Comment.create(comment);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Gets comment by id.
+   * @param {object} id The id would be easier..
+   * @returns {object} The comment object.
+   */
+  static async getCommentById(id) {
+    try {
+      return await Comment.findOne({
+        where: [{ id }]
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Gets comments by request.
+   * @param {object} request The id would be easier..
+   * @returns {object} The comment object.
+   */
+  static async getCommentsByRequest(request) {
+    try {
+      return await Comment.findAll({
+        where: [{ request }],
+        order: [['createdAt', 'ASC']],
+        attributes: ['id', 'user', 'comment']
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Gets comments by request.
+   * @param {object} id The id of the comment
+   * @param {object} comment The new comment
+   * @returns {object} The response object.
+   */
+  static async updateComment(id, comment) {
+    try {
+      return await Comment.update(comment, {
+        returning: true,
+        where: [{ id }]
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+export default CommentService;

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -29,6 +29,29 @@ class RequestService {
 
   /**
    * Get requests by user
+   * @param {string} id to be checked against
+   * @return {object} Oject of request if found
+   */
+  static async findRequestByID(id) {
+    try {
+      const requests = await Requests.findOne({
+        where: { id },
+        include: [
+          {
+            model: database.Accommodations,
+            as: 'accommodations'
+          }
+        ]
+      });
+
+      return requests;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Get requests by user
    * @param {string} request to be created
    * @param {string} acc to array of accomodations
    * @return {object} Oject of request if found

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -22,6 +22,10 @@
       {
         "name": "requests",
         "description": "Requests end points"
+      },
+      {
+        "name": "request comments",
+        "description": "Comments end points"
       }
     ],
     "schemes": [
@@ -187,7 +191,7 @@
     "/auth/createLink": {
       "post": {
         "tags": [
-          "auth"
+          "user"
         ],
         "summary": "Verification link",
         "description": "Sends a verification link to email",
@@ -237,7 +241,7 @@
     "/auth/verify/?token={token}": {
       "patch": {
         "tags": [
-          "auth"
+          "user"
         ],
         "summary": "Verification link",
         "description": "Sends a verification link to email",
@@ -1011,6 +1015,131 @@
         ]
       }
     }
+   },
+   "/requests/{request}/comment":{
+    "post": {
+      "tags": [
+        "request comments"
+      ],
+      "summary": "Add a comment on the request",
+      "description": "This end points allows the manager or the request owner to comment on the request",
+      "consumes": [
+        "application/json"
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        {
+          "name": "request",
+          "in": "path",
+          "description": "Request ID",
+          "required": true,
+          "type": "integer"
+        },
+        {
+          "in": "body",
+          "name": "body",
+          "description": "Payload to add comment",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/comment"
+          }
+        }
+      ],
+      "responses": {
+        "201": {
+          "description": "Comment successfully added"
+        },
+        "422": {
+          "description": "Wrong Data format is entered"
+        },
+        "403": {
+          "description": "Not allowed to comment on request"
+        },
+        "500": {
+          "description": "Server Error"
+        }
+      }
+    }
+   },
+   "/requests/comments/{id}": {
+    "put": {
+      "tags": [
+        "request comments"
+      ],
+      "summary": "Update a comment",
+      "description": "This endpoint allows the request owner or the manager to update their comment on a request",
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "Comment ID",
+          "required": true,
+          "type": "integer"
+        },
+        {
+          "in": "body",
+          "name": "body",
+          "description": "Payload to update comment",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/comment"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Comment successfully updated"
+        },
+        "422": {
+          "description": "Wrong Data format is entered"
+        },
+        "403": {
+          "description": "Not allowed to update comment on request"
+        },
+        "500": {
+          "description": "Server Error"
+        }
+      }
+    }
+  },
+  "/requests/{request}/comments": {
+    "get": {
+      "tags": [
+        "request comments"
+      ],
+      "summary": "View comments on a request",
+      "description": "On this endpoint, a request owner or manager can retrieve comments on the requests",
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [{
+        "name": "request",
+        "in": "path",
+        "required": true,
+        "description": "Request ID",
+        "type": "string"
+      }],
+      "responses": {
+        "200": {
+          "description": "Comments successfully retrieved"
+        },
+        "404": {
+          "description": "Request not found"
+        },
+        "403": {
+          "description": "Not allowed to retrieve comments on request"
+        },
+        "500": {
+          "description": "Server Error"
+        }
+      }
+    }
+  }
   },
   "definitions": {
     "oneWay": {
@@ -1080,6 +1209,19 @@
       "xml": {
         "name": "User"
       }
+    },
+    "comment": {
+      "required": [
+        "comment"
+      ],
+      "type": "object",
+      "properties": {
+        "comment": {
+          "type": "string",
+          "example": "Please clarify the travel reason",
+          "summary": "This is an updated comment on the request"
+        }
+      }
     }
   },
   "/requests/returnTrip":{
@@ -1121,7 +1263,6 @@
         }
       }
     }
-   }
   },
   "security": [
     {

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -2,7 +2,6 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../index';
-import Requests from '../controllers/requestController';
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -13,6 +12,12 @@ const signinUrl = '/api/v1/auth/signin';
 const getMyRequestUrl = '/api/v1/requests/my-requests';
 const oneway = '/api/v1/requests/oneWay';
 const returnTrip = '/api/v1/requests/returnTrip';
+const getRequestCommentsUrl = '/api/v1/requests/1/comments';
+const addRequestCommentUrl = '/api/v1/requests/1/comment';
+const invalidRequestIdUrl = '/api/v1/requests/a/comment';
+const invalidRequestIdUrlGet = '/api/v1/requests/a/comments';
+const updateComment = '/api/v1/requests/comments/1';
+const InvalidUpdateUrl = '/api/v1/requests/comments/a';
 
 const oneWay = {
   from: 'Kigali, Rwanda',
@@ -69,6 +74,12 @@ const WrongDescription = {
   reason: 'iam travelling cause',
   accommodation: 1
 };
+const comment = {
+  comment: 'This is a sample comment'
+};
+const invalidComment = {
+  comment: null
+};
 
 const returnTripData = {
   from: 'Kigali, Rwanda',
@@ -89,7 +100,7 @@ const wrongreturnDate = {
   accommodation: 1
 };
 
-describe('Get Requests', () => {
+describe('Travel Requests', () => {
   before('with correct credentials', (done) => {
     const user = {
       userEmail: 'jonashyaka2@gmail.com',
@@ -111,7 +122,7 @@ describe('Get Requests', () => {
         done();
       });
   });
-  it('when they are logged In', (done) => {
+  it('should retrieve requests', (done) => {
     chai
       .request(server)
       .get(getMyRequestUrl)
@@ -243,5 +254,103 @@ describe('Get Requests', () => {
         expect(res.status).to.eq(422);
         done();
       });
+  });
+  describe('Request Comments', () => {
+    it('should retrieve comments', (done) => {
+      chai
+        .request(server)
+        .get(getRequestCommentsUrl)
+        .set('Authorization', `Bearer ${token}`)
+        .send()
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(200);
+          done();
+        });
+    });
+    it('should have valid request url', (done) => {
+      chai
+        .request(server)
+        .get(invalidRequestIdUrlGet)
+        .set('Authorization', `Bearer ${token}`)
+        .send()
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(422);
+          done();
+        });
+    });
+    it('should add comment', (done) => {
+      chai
+        .request(server)
+        .post(addRequestCommentUrl)
+        .set('Authorization', `Bearer ${token}`)
+        .send(comment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(201);
+          done();
+        });
+    });
+    it('should have a valid comment', (done) => {
+      chai
+        .request(server)
+        .post(addRequestCommentUrl)
+        .set('Authorization', `Bearer ${token}`)
+        .send(invalidComment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(422);
+          done();
+        });
+    });
+    it('should have a valid request id', (done) => {
+      chai
+        .request(server)
+        .post(invalidRequestIdUrl)
+        .set('Authorization', `Bearer ${token}`)
+        .send(comment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(422);
+          done();
+        });
+    });
+    it('should update comment', (done) => {
+      chai
+        .request(server)
+        .put(updateComment)
+        .set('Authorization', `Bearer ${token}`)
+        .send(comment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(200);
+          done();
+        });
+    });
+    it('should have a valid comment id', (done) => {
+      chai
+        .request(server)
+        .put(InvalidUpdateUrl)
+        .set('Authorization', `Bearer ${token}`)
+        .send(comment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(422);
+          done();
+        });
+    });
+    it('should update comment', (done) => {
+      chai
+        .request(server)
+        .put(updateComment)
+        .set('Authorization', `Bearer ${token}`)
+        .send(invalidComment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(422);
+          done();
+        });
+    });
   });
 });

--- a/src/validation/commentValidator.js
+++ b/src/validation/commentValidator.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-unused-vars */
+import Joi from '@hapi/joi';
+import Response from '../utils/response';
+
+/**
+ * @class commentValidation
+ */
+export default class commentValidator {
+  /**
+   * @param {Object} req  request details.
+   * @param {Object} res  response details.
+   * @param {Object} next middleware details
+   * @returns {Object}.
+   */
+  static async getComments(req, res, next) {
+    const comment = req.body;
+    comment.request = req.params.id;
+    const schema = Joi.object()
+      .keys({
+        request: Joi.number()
+          .integer()
+          .required()
+          .error(() => 'Enter a valid comment ID')
+      })
+      .options({ allowUnknown: false });
+
+    schema.validate(comment, (error) => {
+      if (error) return Response.errorResponse(res, 422, 'Validation failed', error.details[0].message);
+      next();
+    });
+  }
+
+  /**
+   * @param {Object} req  request details.
+   * @param {Object} res  response details.
+   * @param {Object} next middleware details
+   * @returns {Object}.
+   */
+  static async addComment(req, res, next) {
+    const comment = req.body;
+    comment.request = req.params.id;
+    const schema = Joi.object()
+      .keys({
+        comment: Joi.string()
+          .trim()
+          .required()
+          .error(() => 'Enter a valid comment'),
+        request: Joi.number()
+          .integer()
+          .required()
+          .error(() => 'Enter a valid request ID')
+      })
+      .options({ allowUnknown: false });
+
+    schema.validate(comment, (error) => {
+      if (error) return Response.errorResponse(res, 422, 'Validation failed', error.details[0].message);
+      next();
+    });
+  }
+
+  /**
+   * @param {Object} req  request details.
+   * @param {Object} res  response details.
+   * @param {Object} next middleware details
+   * @returns {Object}.
+   */
+  static async updateComment(req, res, next) {
+    const comment = req.body;
+    comment.id = req.params.id;
+    const schema = Joi.object()
+      .keys({
+        comment: Joi.string()
+          .trim()
+          .required()
+          .error(() => 'Enter a valid comment'),
+        id: Joi.number()
+          .integer()
+          .required()
+          .error(() => 'Enter a valid comment ID')
+      })
+      .options({ allowUnknown: false });
+
+    schema.validate(comment, (error) => {
+      if (error) return Response.errorResponse(res, 422, 'Validation failed', error.details[0].message);
+      next();
+    });
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Allows to comment on Travel requests
#### Description of Task to be completed?
- Implement adding comments on requests by their owner or manager
- Implement updating comments on requests by their owners
- Implement retrieving comments on requests by their owners or manager
#### How should this be manually tested?
- Clone this repo
- Checkout to branch `ft-add-requests-comments-168131428`
- Run `npm test`
- Run the application with `npm run start:dev` and after you successfully log in make these requests
1. `POST` request to `api/v1/requests/{request id}/comment` (Screenshot 1)
The payload should look like this
```
{
	"comment": "Comment Sample"
}
```
2. `PUT` request to `api/v1/requests/comments/{comment id}` (Screenshot 2)
The payload should look like this
```
{
	"comment": "Updated Comment"
}
```
3. `GET` request to `api/v1/requests/{request id}/comments` (Screenshot 3)

- After you make the request you should see a response that looks like the one in screenshots

- Alternatively, you can test using the Heroku Review App `https://mervels-bn-backend-stagi-pr-33.herokuapp.com`
#### Any background context you want to provide?
You can comment only on your requests unless you are logged in as a manager
#### What are the relevant pivotal tracker stories?
[#168131428](https://www.pivotaltracker.com/story/show/168131428)
#### Screenshots (if appropriate)
Screenshot 1
![image](https://user-images.githubusercontent.com/50402526/65439110-f27e5580-de26-11e9-88e1-e565078475f4.png)

Screenshot 2
![image](https://user-images.githubusercontent.com/50402526/65439119-f6aa7300-de26-11e9-88ac-594f567be656.png)

Screenshot 3
![image](https://user-images.githubusercontent.com/50402526/65439140-fca05400-de26-11e9-8846-77a551dd3b48.png)
#### Questions:
N/A