### PR TITLE
#168131443 Users should be able to like/unlike an accommodation facility

### DIFF
--- a/src/database/migrations/20190924213133-create-like.js
+++ b/src/database/migrations/20190924213133-create-like.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Likes', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user: {
+      type: Sequelize.INTEGER
+    },
+    accommodation: {
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('Likes')
+};

--- a/src/database/models/accommodations.js
+++ b/src/database/models/accommodations.js
@@ -40,6 +40,11 @@ const accommodations = (sequelize, DataTypes) => {
       as: 'requests',
       foreignKey: 'accommodationId'
     });
+    Accommodations.hasMany(models.Like, {
+      foreignKey: 'accommodation',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
   };
   return Accommodations;
 };

--- a/src/database/models/like.js
+++ b/src/database/models/like.js
@@ -1,0 +1,34 @@
+export default (sequelize, DataTypes) => {
+  const Like = sequelize.define(
+    'Like',
+    {
+      user: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        validate: {
+          isNumeric: true
+        }
+      },
+      accommodation: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        validate: {
+          isNumeric: true
+        }
+      }
+    },
+    {}
+  );
+  Like.associate = (models) => {
+    Like.belongsTo(models.Accommodations, {
+      foreignKey: 'accommodation',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
+    Like.belongsTo(models.Users, {
+      foreignKey: 'user',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Like;
+};

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -58,6 +58,9 @@ export default (sequelize, DataTypes) => {
     Users.hasMany(models.Comment, {
       foreignKey: 'user'
     });
+    Users.hasMany(models.Like, {
+      foreignKey: 'user'
+    });
   };
   return Users;
 };

--- a/src/routes/api/accommodations.js
+++ b/src/routes/api/accommodations.js
@@ -33,5 +33,11 @@ router.get(
   accommodationValidator.validateGetOneAccommodation,
   Accommodations.getAccommodationById
 );
+router.patch(
+  '/:accommodationId/like',
+  verify,
+  accommodationValidator.validateGetOneAccommodation,
+  Accommodations.likeOrUnlike
+);
 
 module.exports = router;

--- a/src/services/accommodationService.js
+++ b/src/services/accommodationService.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-useless-catch */
+import sequelize from 'sequelize';
 import database from '../database/models';
 
 const { Accommodations, Rooms } = database;
@@ -38,12 +39,32 @@ class AccommodationService {
   static async getAllAccommodations() {
     try {
       return await Accommodations.findAll({
+        subQuery: false,
+        group: ['Accommodations.id'],
+        attributes: [
+          'id',
+          'name',
+          'status',
+          'imageUrl',
+          'locationId',
+          [sequelize.fn('count', sequelize.col('Likes.accommodation')), 'likes'],
+          [sequelize.fn('count', sequelize.col('Rooms.accommodationId')), 'rooms']
+        ],
         include: [
           {
             model: database.Rooms,
-            as: 'Rooms'
+            as: 'Rooms',
+            attributes: [],
+            duplicating: false
+          },
+          {
+            model: database.Like,
+            as: 'Likes',
+            attributes: [],
+            duplicating: false
           }
-        ]
+        ],
+        raw: true
       });
     } catch (error) {
       throw error;
@@ -63,6 +84,9 @@ class AccommodationService {
           {
             model: database.Rooms,
             as: 'Rooms'
+          },
+          {
+            model: database.Like
           }
         ]
       });

--- a/src/services/likeService.js
+++ b/src/services/likeService.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-useless-catch */
+import database from '../database/models';
+
+const { Like } = database;
+
+/** Class representing a Comment service */
+class LikeService {
+  /**
+   * Gets comment by id.
+   * @param {object} like The id would be easier..
+   * @returns {object} The comment object.
+   */
+  static async checkLiked(like) {
+    try {
+      return await Like.count({
+        where: [like]
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Creates a new comment.
+   * @param {object} like The first number.
+   * @returns {object} The User object.
+   */
+  static async like(like) {
+    try {
+      return await Like.create(like);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Gets comment by id.
+   * @param {object} like The id would be easier..
+   * @returns {object} The comment object.
+   */
+  static async unlike(like) {
+    try {
+      return await Like.destroy({
+        where: [like]
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+export default LikeService;

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -278,13 +278,6 @@
             }
           }
         },
-        "securityDefinitions": {
-          "api_key": {
-            "type": "apiKey",
-            "name": "authorization",
-            "in": "header"
-          }
-        },
         "definitions": {
           "Request": {
             "required": [
@@ -820,6 +813,41 @@
             "status": 404,
             "message": "error",
             "error": "Accommodation not found"
+          }
+        }
+      }
+    },
+    "/accommodations/{id}/like": {
+      "patch": {
+        "tags": [
+          "accommodation"
+        ],
+        "summary": "Like or Unlike an accommodation",
+        "description": "This endpoint allows the user to like an accommodation or unlike it if already liked",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Accommodation ID",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully liked or unliked accommodation"
+          },
+          "422": {
+            "description": "Wrong Data format is entered"
+          },
+          "404": {
+            "description": "Accommodation not found"
+          },
+          "500": {
+            "description": "Server Error"
           }
         }
       }
@@ -1516,7 +1544,14 @@
         }
       }
     }
-   },
+  },
+  "securityDefinitions": {
+    "Bearer": { 
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
   "security": [
     {
       "Bearer": []

--- a/src/test/accommodation.test.js
+++ b/src/test/accommodation.test.js
@@ -239,4 +239,46 @@ describe('Travel Administrator', () => {
         done();
       });
   });
+  it('should like an accommodation', (done) => {
+    chai
+      .request(server)
+      .patch('/api/v1/accommodations/1/like')
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .end((_err, res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body.data).to.eq('liked');
+        done();
+      });
+  });
+  it('should unlike the liked accommodation', (done) => {
+    chai
+      .request(server)
+      .patch('/api/v1/accommodations/1/like')
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .end((_err, res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body.data).to.eq('unliked');
+        done();
+      });
+  });
+  it('should like or unlike an accommodation if it exists', (done) => {
+    chai
+      .request(server)
+      .patch('/api/v1/accommodations/124/like')
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .end((_err, res) => {
+        expect(res.status).to.eq(404);
+        done();
+      });
+  });
+  it('should like or unlike an accommodation with a valid id', (done) => {
+    chai
+      .request(server)
+      .patch('/api/v1/accommodations/a/like')
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .end((_err, res) => {
+        expect(res.status).to.eq(422);
+        done();
+      });
+  });
 });

--- a/src/test/multicity.test.js
+++ b/src/test/multicity.test.js
@@ -32,15 +32,6 @@ const multi = {
     'iam travelling cause the company allows us to, i mean the company finances everything so why not',
   accommodation: ['hotel', 'Sheraton']
 };
-const nonMatch = {
-  from: 'Kigali, Rwanda',
-  to: [1, 2, 3],
-  travelDate: ['2040-11-02', '2040-11-12'],
-  returnDate: '2040-12-02',
-  reason:
-    'iam travelling cause the company allows us to, i mean the company finances everything so why not',
-  accommodation: ['hotel', 'Sheraton']
-};
 const multiDate = {
   from: 'Kiigali, Rwanda',
   to: [1, 2],
@@ -134,18 +125,6 @@ describe('Multicity Request', () => {
       .post(multiCity)
       .set('Authorization', `Bearer ${token}`)
       .send(multi)
-      .end((_err, res) => {
-        if (_err) done(_err);
-        expect(res.status).to.eq(400);
-        done();
-      });
-  });
-  it('User shouldnot request for a non matching fields', (done) => {
-    chai
-      .request(server)
-      .post(multiCity)
-      .set('Authorization', `Bearer ${token}`)
-      .send(nonMatch)
       .end((_err, res) => {
         if (_err) done(_err);
         expect(res.status).to.eq(400);

--- a/src/validation/accommodationValidation.js
+++ b/src/validation/accommodationValidation.js
@@ -71,6 +71,7 @@ export default class accommodationValidator {
   static async validateGetOneAccommodation(req, res, next) {
     const schema = Joi.object().keys({
       accommodationId: Joi.number()
+        .integer()
         .min(1)
         .required()
         .error(() => 'accommodationId is required and must be a number greater than zero')


### PR DESCRIPTION
#### What does this PR do?
Allows users to like/unlike an accommodation facility
#### Description of Task to be completed?
- Implement liking and disliking accommodations
#### How should this be manually tested?
- Clone this repo
- Checkout to branch `ft-like-unlike-accommodations-168131443`
- Run `npm test`
- Run migrations `npm run db-migrate:dev`
- Run the application with `npm run start:dev` and after you successfully log in make this requests `PATCH` request to `api/v1/accommodations/{accommodation id}/like`
- After you make the request you should see responses that look like the ones in the screenshot
- Alternatively, you can test using the Heroku Review App `https://mervels-bn-backend-stagi-pr-39.herokuapp.com`
#### Any background context you want to provide?
- When you hit endpoint for the first time it likes (Screenshot 1), when you hit it again it dislikes (Screenshot 2).
- When you fetch all the accommodations, you will see the number of likes (Screenshot 3)
- When you fetch one accommodation, you will see the number and all the likes (Screensho4)
#### What are the relevant pivotal tracker stories?
[#168131443](https://www.pivotaltracker.com/story/show/168131443)
#### Screenshots (if appropriate)

Screenshot 1
![image](https://user-images.githubusercontent.com/50402526/65591414-c381f400-df8c-11e9-82f0-2c15c02862f6.png)


Screenshot 2
![image](https://user-images.githubusercontent.com/50402526/65591423-ca106b80-df8c-11e9-9e65-0c0fb1b55b95.png)


Screenshot 3
![image](https://user-images.githubusercontent.com/50402526/65624000-4628a480-dfc9-11e9-8db6-0effa6f8c971.png)


Screenshot 4
![image](https://user-images.githubusercontent.com/50402526/65624030-5771b100-dfc9-11e9-853e-0b363427a79d.png)


#### Questions:
N/A