### PR TITLE
#168131446 Users should get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable class-methods-use-this */
+import moment from 'moment';
+import { Op } from 'sequelize';
 import requestService from '../services/requestService';
 import Response from '../utils/response';
 import email from '../utils/mails/email';
@@ -203,6 +205,34 @@ class Requests {
       return Response.customResponse(res, 200, 'Update has been completed successfully', data);
     } catch (error) {
       return Response.errorResponse(res, 500, 'Something went wrong', error);
+    }
+  }
+
+  /**
+   * @param {object} req request
+   * @param {object} res response
+   * @param {object} next next
+   * @return {function} Get requests with pending status
+   */
+  async statistics(req, res, next) {
+    try {
+      const params = {
+        travelDate: {
+          [Op.gte]: [
+            moment()
+              .subtract(req.body.value, req.body.parameter)
+              .format('YYYY-MM-DD')
+          ],
+          [Op.lt]: [moment().format('YYYY-MM-DD')]
+        },
+        status: 'Approved',
+        user: req.user.id
+      };
+      const data = await requestService.findRequests(params);
+      const message = 'Trip Statistics Succesfully retrieved';
+      return Response.customResponse(res, 200, message, { total: data.length, trips: data });
+    } catch (error) {
+      return next(error);
     }
   }
 }

--- a/src/database/seeders/20190916205822-demo-request.js
+++ b/src/database/seeders/20190916205822-demo-request.js
@@ -12,6 +12,56 @@ export default {
         user: 5,
         createdAt: new Date(),
         updatedAt: new Date()
+      },
+      {
+        from: 'ACCRA, GHANA',
+        travelDate: ['2019-08-01'],
+        returnDate: '2019-12-12',
+        reason: 'Business Travel',
+        status: 'Approved',
+        user: 3,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        from: 'MANILLA, PHILIPINES',
+        travelDate: ['2019-07-01'],
+        returnDate: '2019-12-12',
+        reason: 'Business Travel',
+        status: 'Rejected',
+        user: 5,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        from: 'NAKURU, KENYA',
+        travelDate: ['2019-04-01', '2019-05-21'],
+        returnDate: '2019-07-12',
+        reason: 'Still figuring this out',
+        status: 'Approved',
+        user: 3,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        from: 'VICTORIA, EAFRICA',
+        travelDate: ['2019-09-01', '2019-10-01'],
+        returnDate: '2019-11-12',
+        reason: 'i want to checkout the nile crocdiles',
+        status: 'Approved',
+        user: 3,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        from: 'UHEA, RWANDEX',
+        travelDate: ['2019-06-21'],
+        returnDate: '2019-09-12',
+        reason: 'this is confidential you dont wanna know',
+        status: 'Approved',
+        user: 3,
+        createdAt: new Date(),
+        updatedAt: new Date()
       }
     ],
     {}

--- a/src/routes/api/requests.js
+++ b/src/routes/api/requests.js
@@ -10,6 +10,10 @@ import location from '../../middlewares/validLocation';
 import Access from '../../middlewares/userRoles';
 
 const router = express.Router();
+router
+  .route('/trip-stats')
+  .post(verify, requestsValidator.statistics, Requests.statistics)
+  .all(method);
 
 router
   .route('/one-way')

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1602,6 +1602,48 @@
           }
         }
       }
+    },
+    "/requests/trip-stats": {
+      "post": {
+        "tags": [
+          "requests"
+        ],
+        "summary": "Trip Statistics",
+        "description": "User can acquire trip statistics in a secified last time frame",
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "parameter",
+            "in": "formData",
+            "description": "Enter time description one of 'months', 'years', 'days' or 'weeks'",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "in": "formData",
+            "description": "Number of the selected time description. (time-frame) ",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Password succesfully updated"
+          },
+          "401": {
+            "description": "unauthorised"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/src/test/statistics.test.js
+++ b/src/test/statistics.test.js
@@ -1,0 +1,78 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../index';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+const signinUrl = '/api/v1/auth/signin';
+const stats = '/api/v1/requests/trip-stats';
+let token;
+const timeFrame = {
+  parameter: 'months',
+  value: 8
+};
+const wrongParameter = {
+  parameter: 'start',
+  value: 8
+};
+const wrongValue = {
+  parameter: 'months',
+  value: 'string value'
+};
+
+describe('Trip Statistics', () => {
+  before('login user with id 3', (done) => {
+    const user = {
+      userEmail: 'jamesdoe@gmail.com',
+      userPassword: 'Root1123#'
+    };
+    chai
+      .request(server)
+      .post(signinUrl)
+      .send(user)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        token = res.body.data.userToken;
+        done();
+      });
+  });
+  it('User should get trip stats', (done) => {
+    chai
+      .request(server)
+      .post(stats)
+      .set('Authorization', `Bearer ${token}`)
+      .send(timeFrame)
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
+        done();
+      });
+  });
+  it('User should not get trip stats with wrong params', (done) => {
+    chai
+      .request(server)
+      .post(stats)
+      .set('Authorization', `Bearer ${token}`)
+      .send(wrongParameter)
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(422);
+        done();
+      });
+  });
+  it('User should not get trip stats with wrong value', (done) => {
+    chai
+      .request(server)
+      .post(stats)
+      .set('Authorization', `Bearer ${token}`)
+      .send(wrongValue)
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(422);
+        done();
+      });
+  });
+});

--- a/src/validation/requestValidator.js
+++ b/src/validation/requestValidator.js
@@ -10,7 +10,29 @@ import validator from '../utils/validator';
  */
 export default class requestValidator {
   /**
-   * resets new password
+   * validates stats data
+   * @param {Object} req  request details.
+   * @param {Object} res  re sponse details.
+   * @param {Object} next middleware details
+   * @returns {Object}.
+   */
+  static async statistics(req, res, next) {
+    const schema = Joi.object().keys({
+      parameter: Joi.string()
+        .trim()
+        .valid('years', 'months', 'days', 'weeks')
+        .required()
+        .error(() => 'Parameter must be one of months,years,weeks,days'),
+      value: Joi.number()
+        .integer()
+        .required()
+        .error(() => 'value must be an integer')
+    });
+    validator(schema, req.body, res, next);
+  }
+
+  /**
+   * Validate one way trip
    * @param {Object} req  request details.
    * @param {Object} res  re sponse details.
    * @param {Object} next middleware details


### PR DESCRIPTION
#### What does this PR do?
- Adds the return made trip statistics in a specified time frame to a user
#### Description of Task to be completed?
- Get time frame from the user
- Get made trips in that time frame 
#### How should this be manually tested?
- Git clone this repo and checkout to this branch
- Run `npm install` and then run `npm run db-migrate:dev"`
- Run `npm run db-seed:test` to run the new seeders
- Run `npm run start:dev` to start server
- login user at `http://localhost:3000/api/v1/auth/signin`
```
{
"userEmail": "jamesdoe@gmail.com",
"userPassword": "Root1123#"
}
```
- Visit `http://localhost:3000/api/v1/requests/trip-stats` on postman and do a POST
```
{
"parameter": "months",
"value": 8
}
```
- Review the stats

#### Any background context you want to provide?
- For parameter you can use either "months, years, weeks or days"
#### What are the relevant pivotal tracker stories?
[168131446](https://www.pivotaltracker.com/story/show/168131446)
#### Screenshots (if appropriate)
<img width="1113" alt="Screen Shot 2019-10-01 at 10 41 36" src="https://user-images.githubusercontent.com/26115429/65949555-b9ed0600-e43c-11e9-8eb0-ae36b9deb315.png">

#### Questions:
N/A