### PR TITLE
#168131436 Users should receive notifications for posted comments

### DIFF
--- a/src/database/models/comment.js
+++ b/src/database/models/comment.js
@@ -1,3 +1,5 @@
+import emitter from '../../utils/eventEmitters/emitter';
+
 export default (sequelize, DataTypes) => {
   const Comment = sequelize.define(
     'Comment',
@@ -38,5 +40,8 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE'
     });
   };
+  Comment.afterCreate(({ dataValues }) => {
+    emitter.emit('new comment', dataValues);
+  });
   return Comment;
 };

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -330,6 +330,18 @@ describe('Get Requests', () => {
           done();
         });
     });
+    it('should add comment as manager', (done) => {
+      chai
+        .request(server)
+        .post(addRequestCommentUrl)
+        .set('Authorization', `Bearer ${managerToken}`)
+        .send(comment)
+        .end((_err, res) => {
+          if (_err) done(_err);
+          expect(res.status).to.eq(201);
+          done();
+        });
+    });
     it('should have a valid comment', (done) => {
       chai
         .request(server)

--- a/src/utils/notifications/index.js
+++ b/src/utils/notifications/index.js
@@ -3,4 +3,5 @@ import requestNotification from './requestNotification';
 module.exports = () => {
   requestNotification.requestCreatedNotification();
   requestNotification.requestUpdated();
+  requestNotification.newComment();
 };


### PR DESCRIPTION
#### What does this PR do?
Integrates sending a notification to both the manager and the requester on new comments
#### Description of Task to be completed?
- Notify requester when the manager comments on their request and vice-versa
#### How should this be manually tested?
- To test the above feature locally you can get info on the setup from this [repo](https://github.com/drayzii/notifications) being used for notifications
- Git clone this repo and checkout to this branch `ft-new-comments-notification-168131436`
- Run `npm run start:dev` to start server
- Login as a manager or requester
- Add a comment on your request if logged in as a requester or any if logged in as a manager by making a `POST` request to `http://localhost:3000/api/v1/requests/{id}/comment`
```
{
  "comment": "Comment Sample"
}
```
- Look out for a push notification. (Screenshots)
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168131436](https://www.pivotaltracker.com/story/show/168131436)
#### Screenshots (if appropriate)
1. Notification to the manager of new comment by the requester
![image](https://user-images.githubusercontent.com/50402526/66140704-dcc91700-e602-11e9-8eaf-55d353b19d2e.png)

1. Notification to the requester of new comment by the manager
![image](https://user-images.githubusercontent.com/50402526/66140720-e3578e80-e602-11e9-9e37-b59427ada65a.png)

#### Questions:
N/A

