### PR TITLE
#168131433 Users should be able to mark all notifications as read

### DIFF
--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -23,5 +23,24 @@ class Notifcations {
       return next(error);
     }
   }
+
+  /**
+   * @param {object} req request
+   * @param {object} res response
+   * @param {object} next next
+   * @return {function} requests
+   */
+  async markAsRead(req, res, next) {
+    try {
+      const param = req.query.id ? { id: req.query.id } : { userId: req.user.id };
+      const data = await notificationService.markAsRead({ ...param, ...{ read: false } });
+      let message = data > 1 ? 'Notifications' : 'Notification';
+      message += ' successfully marked as read';
+      if (data[0] === 0) message = 'No Notifications marked as read';
+      return Response.customResponse(res, 200, message, `${data} marked as read`);
+    } catch (error) {
+      return next(error);
+    }
+  }
 }
 export default new Notifcations();

--- a/src/database/migrations/20191007082044-add-read-column.js
+++ b/src/database/migrations/20191007082044-add-read-column.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars */
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Notifications', 'read', {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Notifications', 'read')
+};

--- a/src/database/models/notifications.js
+++ b/src/database/models/notifications.js
@@ -12,6 +12,10 @@ export default (sequelize, DataTypes) => {
       requestId: {
         allowNull: true,
         type: DataTypes.STRING
+      },
+      read: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
       }
     },
     {}

--- a/src/middlewares/userRoles.js
+++ b/src/middlewares/userRoles.js
@@ -2,6 +2,7 @@
 import Response from '../utils/response';
 import RequestService from '../services/requestService';
 import CommentService from '../services/commentService';
+import NotificationService from '../services/notificationService';
 /** Class representing a UserRole. */
 class Access {
   /**
@@ -66,6 +67,26 @@ class Access {
     }
     if (req.user.id !== comment.user) {
       return Response.authorizationError(res, "You don't have rights to complete this operation");
+    }
+    next();
+  }
+
+  /**
+   * Checks if the user is the request owner or manager.
+   *@param {string} req  data.
+   * @param {string} res  data.
+   * @param {string} next data.
+   * @returns {string} object.
+   */
+  static async isNotificationOwner(req, res, next) {
+    if (req.query.id) {
+      const data = await NotificationService.getNotifications({ id: req.query.id });
+      if (data.notifications.length === 0) {
+        return Response.notFoundError(res, 'Please use a valid notification ID');
+      }
+      if (req.user.id !== data.notifications[0].dataValues.userId) {
+        return Response.authorizationError(res, "You can't mark this notification as read");
+      }
     }
     next();
   }

--- a/src/routes/api/notifications.js
+++ b/src/routes/api/notifications.js
@@ -1,9 +1,18 @@
 import express from 'express';
 import notificationController from '../../controllers/notificationController';
 import verify from '../../middlewares/auth';
+import Access from '../../middlewares/userRoles';
+import Validator from '../../validation/notificationValidator';
 
 const router = express.Router();
 
 router.get('/', verify, notificationController.getNotifications);
+router.patch(
+  '/mark-as-read',
+  verify,
+  Validator.markAsRead,
+  Access.isNotificationOwner,
+  notificationController.markAsRead
+);
 
 export default router;

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -17,14 +17,39 @@ class NotificationService {
 
   /**
    * Creates a new notification.
-   * @param {object} userId notification
+   * @param {object} param notification
    * @returns {object} The notification object.
    */
-  static async getNotifications(userId) {
+  static async getNotifications(param) {
     const results = await Notifications.findAll({
-      where: userId
+      where: param,
+      order: [['read', 'ASC'], ['createdAt', 'DESC']]
     });
-    return results;
+    const unread = await Notifications.count({
+      where: {
+        ...param,
+        read: false
+      }
+    });
+    return {
+      unread,
+      notifications: results
+    };
+  }
+
+  /**
+   * Creates a new notification.
+   * @param {object} param notification
+   * @returns {object} The notification object.
+   */
+  static async markAsRead(param) {
+    const deleted = await Notifications.update(
+      { read: true },
+      {
+        where: param
+      }
+    );
+    return deleted;
   }
 }
 export default NotificationService;

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -481,6 +481,41 @@
         }
       }
     },
+    "/notifications/mark-as-read": {
+      "patch": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark one or all notifications as read",
+        "description": "This endpoint allows the user to mark one or all his/her notifications as read. You pass in an id to mark one as read, or leave it to mark all as read",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name" : "id",
+            "in" : "query",
+            "description" : "Notification ID",
+            "required" : false,
+            "type" : "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification(s) successfully marked as read"
+          },
+          "422": {
+            "description": "Wrong Data format is entered"
+          },
+          "404": {
+            "description": "Notification not found"
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
     "/notifications": {
       "get": {
         "tags": [

--- a/src/test/notifications.test.js
+++ b/src/test/notifications.test.js
@@ -12,6 +12,8 @@ let managerToken;
 
 const signinUrl = '/api/v1/auth/signin';
 const getNotifications = '/api/v1/notifications';
+const markOneAsRead = '/api/v1/notifications/mark-as-read?id=1';
+const markAllAsRead = '/api/v1/notifications/mark-as-read';
 
 before('Log In manager correct credentials', (done) => {
   const user = {
@@ -35,11 +37,35 @@ before('Log In manager correct credentials', (done) => {
     });
 });
 
-describe('Get Requests', () => {
-  it('when they are logged In', (done) => {
+describe('Notifications', () => {
+  it('should retrieve all', (done) => {
     chai
       .request(server)
       .get(getNotifications)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send()
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
+        done();
+      });
+  });
+  it('should mark one notification as read', (done) => {
+    chai
+      .request(server)
+      .patch(markOneAsRead)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send()
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
+        done();
+      });
+  });
+  it('should not mark as read if already marked', (done) => {
+    chai
+      .request(server)
+      .patch(markAllAsRead)
       .set('Authorization', `Bearer ${managerToken}`)
       .send()
       .end((_err, res) => {

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -22,6 +22,7 @@ const updateComment = '/api/v1/requests/comments/1';
 const InvalidUpdateUrl = '/api/v1/requests/comments/a';
 const pendingApprovals = '/api/v1/requests/pending';
 const updateResquest = '/api/v1/requests/1';
+const markAllAsRead = '/api/v1/notifications/mark-as-read';
 
 const oneWay = {
   from: 'Kigali, Rwanda',
@@ -818,6 +819,20 @@ describe('Update Requests', () => {
       .end((_err, res) => {
         if (_err) done(_err);
         expect(res.status).to.eq(422);
+        done();
+      });
+  });
+});
+describe('Notifications', () => {
+  it('should mark all as read', (done) => {
+    chai
+      .request(server)
+      .patch(markAllAsRead)
+      .set('Authorization', `Bearer ${managerToken}`)
+      .send()
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
         done();
       });
   });

--- a/src/validation/notificationValidator.js
+++ b/src/validation/notificationValidator.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-unused-vars */
+import Joi from '@hapi/joi';
+import Schema from './schema';
+import validator from '../utils/validator';
+
+/**
+ * @class commentValidation
+ */
+export default class commentValidator {
+  /**
+   * @param {Object} req  request details.
+   * @param {Object} res  response details.
+   * @param {Object} next middleware details
+   * @returns {Object}.
+   */
+  static async markAsRead(req, res, next) {
+    const schema = Joi.object()
+      .keys({
+        id: Schema.idOptional
+      })
+      .options({ allowUnknown: false });
+    validator(schema, req.query, res, next);
+  }
+}

--- a/src/validation/schema/index.js
+++ b/src/validation/schema/index.js
@@ -41,6 +41,10 @@ export default {
     .integer()
     .min(0)
     .required(),
+  idOptional: Joi.number()
+    .integer()
+    .min(0)
+    .optional(),
   string: Joi.string()
     .trim()
     .min(1)


### PR DESCRIPTION
#### What does this PR do?
Allows users to mark notifications as read
#### Description of Task to be completed?
Implement marking notifications as read, which will update all the notifications' read attributes to true
#### How should this be manually tested?
- Clone this repo
- Checkout to branch `ft-mark-notifications-read-168131433`
- Log in
- Make a `PATCH` request to `api/v1/notifications/mark-as-read` to mark all your notifications as read (Screenshot 1)
- You can also mark one notification as read by passing in an ID as a query parameter, i.e `PATCH` request to `api/v1/notifications/mark-as-read?id={id}` (Screenshot 2)
- You should get a notification looking like the one in the screenshot
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168131433](https://www.pivotaltracker.com/story/show/168131433)
#### Screenshots (if appropriate)
1.
![image](https://user-images.githubusercontent.com/50402526/66329408-bf5fba00-e92e-11e9-8f78-aa64848df7ff.png)

2.
![image](https://user-images.githubusercontent.com/50402526/66329393-b7077f00-e92e-11e9-9aff-3016d33fc687.png)

#### Questions:
N/A