### PR TITLE
Implement viewing and updating a profile picture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ node_js:
   - stable
 notifications:
   email: false
-cache:
-  directories:
-    - node_modules
 install:
   - npm install
 services:

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -196,8 +196,11 @@ class Users {
         res.cookie('passportNumber', profileData.passportNumber);
         res.cookie('passportName', profileData.passportName);
         res.cookie('gender', profileData.gender);
+      } else {
+        res.cookie('passportNumber', null);
+        res.cookie('passportName', null);
+        res.cookie('gender', null);
       }
-
       return Response.customResponse(res, 200, 'User signed In successfully', user);
     } catch (error) {
       return next(error);

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -3,6 +3,7 @@
 import UserProfileService from '../services/userProfileService';
 import UserService from '../services/userService';
 import Response from '../utils/response';
+import uploader from '../utils/cloudinary';
 
 class userProfileController {
   async updateProfile(req, res, next) {
@@ -29,6 +30,30 @@ class userProfileController {
       const profile = await UserProfileService.getProfile(userId);
 
       return Response.customResponse(res, 200, 'User Profile Updated', profile);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async updatePicture(req, res, next) {
+    try {
+      const { image } = req.files;
+      const cloudFile = await uploader(image.tempFilePath);
+      req.body.url = cloudFile.url;
+      const user = req.user.id;
+      const response = await UserProfileService.updateOrCreatePicture(user, req.body);
+      return Response.customResponse(res, 200, 'Profile Picture Updated', response[1][0]);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  async getPicture(req, res, next) {
+    try {
+      const user = req.user.id;
+      const response = await UserProfileService.getPicture(user);
+
+      return Response.customResponse(res, 200, 'Profile Picture Retrieved', response);
     } catch (error) {
       return next(error);
     }

--- a/src/database/migrations/20191107123810-create-profile-pictures.js
+++ b/src/database/migrations/20191107123810-create-profile-pictures.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ProfilePictures', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user: {
+      type: Sequelize.INTEGER
+    },
+    url: {
+      type: Sequelize.STRING
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('ProfilePictures')
+};

--- a/src/database/models/profilepictures.js
+++ b/src/database/models/profilepictures.js
@@ -1,0 +1,17 @@
+export default (sequelize, DataTypes) => {
+  const ProfilePictures = sequelize.define(
+    'ProfilePictures',
+    {
+      user: DataTypes.INTEGER,
+      url: DataTypes.STRING
+    },
+    {}
+  );
+  ProfilePictures.associate = (models) => {
+    ProfilePictures.belongsTo(models.Users, {
+      foreignKey: 'user',
+      onDelete: 'CASCADE'
+    });
+  };
+  return ProfilePictures;
+};

--- a/src/routes/api/userProfile.js
+++ b/src/routes/api/userProfile.js
@@ -1,11 +1,16 @@
 import express from 'express';
+import fileupload from 'express-fileupload';
 import userProfileController from '../../controllers/userProfileController';
 import auth from '../../middlewares/auth';
 import userProfileValidator from '../../validation/userProfileValidator';
 
 const router = express.Router();
 
+router.use(fileupload({ useTempFiles: true }));
+
 router.patch('/', auth, userProfileValidator.checkUpdate, userProfileController.updateProfile);
 router.get('/', auth, userProfileController.userProfile);
+router.patch('/picture', auth, userProfileController.updatePicture);
+router.get('/picture', auth, userProfileController.getPicture);
 
 export default router;

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -1,8 +1,9 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable require-jsdoc */
 /* eslint-disable no-useless-catch */
 import database from '../database/models';
 
-const { UserProfile } = database;
-const { Users } = database;
+const { UserProfile, Users, ProfilePictures } = database;
 
 class UserProfileService {
   async updateOrCreate(userId, profileData = null) {
@@ -32,6 +33,30 @@ class UserProfileService {
       });
 
       return profile;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async updateOrCreatePicture(user, data) {
+    try {
+      const profileFound = await ProfilePictures.findOne({ where: { user } });
+      if (!profileFound) await ProfilePictures.create({ user });
+      const updatedProfile = await ProfilePictures.update(data, {
+        where: { user },
+        returning: true
+      });
+      return updatedProfile;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async getPicture(user) {
+    try {
+      return await ProfilePictures.findOne({
+        where: { user }
+      });
     } catch (error) {
       throw error;
     }

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -28,7 +28,7 @@ const markAllAsRead = '/api/v1/notifications/mark-as-read';
 const oneWay = {
   from: 'Kigali, Rwanda',
   to: 1,
-  travelDate: '2019-11-02',
+  travelDate: '2020-11-02',
   reason:
     'iam travelling cause the company allows us to, i mean the company finances everything so why not',
   accommodation: 'hotel',
@@ -85,7 +85,7 @@ const noGender = {
 const wrongLocation = {
   from: 'Kigali, Rwanda',
   to: 90,
-  travelDate: '2019-11-02',
+  travelDate: '2020-11-02',
   reason:
     'iam travelling cause the company allows us to, i mean the company finances everything so why not',
   accommodation: 'Hotel',
@@ -599,7 +599,7 @@ describe('Reject request', () => {
     const request = {
       from: 'Kigali, Rwanda',
       to: 1,
-      travelDate: '2019-11-04',
+      travelDate: '2020-11-04',
       reason:
         'I am travelling cause the company allows us to, i mean the company finances everything so why not?',
       accommodation: 'hotel',
@@ -713,7 +713,7 @@ describe('Accept request', () => {
     const request = {
       from: 'Kigali, Rwanda',
       to: 1,
-      travelDate: '2019-11-03',
+      travelDate: '2020-11-03',
       reason:
         'I am travelling cause the company allows us to, i mean the company finances everything so why not?',
       accommodation: 'hotel',
@@ -871,8 +871,8 @@ describe('Update Requests', () => {
       .send({
         from: 'Kigali, Rwanda',
         to: 1,
-        travelDate: '2019-11-02',
-        returnDate: '2019-11-04',
+        travelDate: '2020-11-02',
+        returnDate: '2020-11-04',
         reason: 'hey the nklnk;joihnbyugvytgtfredersg;lklmnjnbvytfyfjo',
         accommodation: 'Hotel'
       })

--- a/src/test/search.test.js
+++ b/src/test/search.test.js
@@ -100,7 +100,7 @@ describe('Search Requests', () => {
   });
 
   it('search request by travelDate', (done) => {
-    const search = `${searchUrl}?travelDate=2019/11/02`;
+    const search = `${searchUrl}?travelDate=2020/11/02`;
     chai
       .request(server)
       .get(search)

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -15,6 +15,7 @@ const signinUrl = '/api/v1/auth/signin';
 const sendLinkUrl = '/api/v1/auth/createLink';
 const updateRole = '/api/v1/auth/updateRole';
 const profileUrl = '/api/v1/profile';
+const profilePictureUrl = '/api/v1/profile/picture';
 
 let token1;
 let superToken;
@@ -598,6 +599,33 @@ describe('User Profile', () => {
         if (_err) done(_err);
 
         expect(res.status).to.eq(422);
+
+        done();
+      });
+  });
+});
+
+describe('User Profile Picture', () => {
+  it('should get user Profile Picture', (done) => {
+    chai
+      .request(server)
+      .get(profilePictureUrl)
+      .set('Authorization', `Bearer ${token}`)
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
+        done();
+      });
+  });
+  it('should update user Profile Picture', (done) => {
+    chai
+      .request(server)
+      .patch(profilePictureUrl)
+      .set('Authorization', `Bearer ${token}`)
+      .attach('image', 'src/test/testData/marvel.png', 'marvel.png')
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
 
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
Implements viewing and updating a profile picture
#### Description of Task to be completed?
N/A
#### How should this be manually tested?
- Clone repo
- Checkout to this branch
- Run migrations `npm run db-migrate:dev`
- Run the app `npm run start:dev`
- You can get and patch on this url `/api/v1/profile/picture` to fetch or update the profile picture respectively.
- To update you will need to send an image under attribute `image` 
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/50402526/68395390-4dba9c00-0178-11ea-9745-28a65f91dba6.png)


![image](https://user-images.githubusercontent.com/50402526/68395347-3380be00-0178-11ea-8bce-a1b850e9eb9f.png)


#### Questions:
N/A