### PR TITLE
bug(requests): fix autofill on user requests

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -447,5 +447,28 @@ class Users {
       return next(error);
     }
   }
+
+  /**
+   * switchAutofill.
+   * @param {object} req  details.
+   * @param {object} res  details.
+   * @param {object} next nest task
+   * @returns {object}.
+   */
+  async switchAutofill(req, res, next) {
+    try {
+      const { id, requestAutofill } = req.user;
+      const data = await userService.updateUser({ id }, { requestAutofill: !requestAutofill });
+      return Response.customResponse(
+        res,
+        200,
+        'Your request autofill preference has been successfully updated',
+        { requestAutofill: data[1][0].requestAutofill }
+      );
+    } catch (error) {
+      return next(error);
+    }
+  }
 }
+
 export default new Users();

--- a/src/database/migrations/20191122045102-add-autofill-preference.js
+++ b/src/database/migrations/20191122045102-add-autofill-preference.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars */
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Users', 'requestAutofill', Sequelize.BOOLEAN),
+  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Users', 'requestAutofill')
+};

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -55,6 +55,11 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: true,
       allowNull: false
+    },
+    requestAutofill: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false
     }
   });
 

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -12,9 +12,10 @@ const verify = async (req, res, next) => {
     if (result === null) return Response.authenticationError(res, 'User not logged In');
     const { userEmail } = payload;
     // checking for the updated userRole from the db not from the token
-    const { userRoles, emailAllowed } = await userService.findUser({ userEmail });
+    const { userRoles, emailAllowed, requestAutofill } = await userService.findUser({ userEmail });
     payload.userRoles = userRoles;
     payload.emailAllowed = emailAllowed;
+    payload.requestAutofill = requestAutofill;
     req.user = payload;
     next();
   } catch (error) {

--- a/src/routes/api/users.js
+++ b/src/routes/api/users.js
@@ -83,6 +83,12 @@ router
   .route('/email-preferences')
   .patch(verify, Users.emailPreferences)
   .all(method);
+
+router
+  .route('/autofill-preference')
+  .patch(verify, Users.switchAutofill)
+  .all(method);
+
 router
   .route('/unsubscribe')
   .patch(userValidator.validateUnsubscribe, Users.unsubscribe)

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -27,7 +27,7 @@ class UserProfileService {
   async getProfile(userId) {
     try {
       const profile = await Users.findOne({
-        attributes: ['firstName', 'lastName', 'userEmail', 'userRoles'],
+        attributes: ['firstName', 'lastName', 'userEmail', 'userRoles', 'requestAutofill'],
         where: { id: userId },
         include: [{ model: UserProfile, as: 'userProfile' }]
       });

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -26,6 +26,7 @@ const googleRedirect = '/api/v1/auth/google/redirect';
 const facebookRedirect = '/api/v1/auth/facebook/redirect';
 const signout = '/api/v1/auth/signout';
 const emailPreferences = '/api/v1/auth/email-preferences';
+const autofillPreference = '/api/v1/auth/autofill-preference';
 
 chai.use(chaiHttp);
 
@@ -650,6 +651,18 @@ describe('Email Preference', () => {
         if (_err) done(_err);
         expect(res.status).to.eq(200);
         expect(res.body.data.emailAllowed).to.eq(true);
+        done();
+      });
+  });
+  it('should update user autofill preference', (done) => {
+    chai
+      .request(server)
+      .patch(autofillPreference)
+      .set('Authorization', `Bearer ${token}`)
+      .end((_err, res) => {
+        if (_err) done(_err);
+        expect(res.status).to.eq(200);
+        expect(res.body.data.requestAutofill).to.eq(true);
         done();
       });
   });

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -31,6 +31,7 @@ class SessionManager {
         lastName: data.lastName,
         accountVerified: data.accountVerified,
         emailAllowed: data.emailAllowed,
+        requestAutofill: data.requestAutofill,
         userRoles: data.userRoles
       },
       data.secret || process.env.TOKEN,


### PR DESCRIPTION
#### What does this PR do?
Fix autofill on user requests
#### Description of Task to be completed?
Add endpoint that allows the user to switch autofill on or off.
#### How should this be manually tested?
- Clone this repo and checkout to this branch
- Run migrations `npm run db-migrate:dev`
- Run tests `npm test`
- Run the app `npm run start:dev`
- Make a `PATCH` on `/auth/autofill-preference`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A